### PR TITLE
feat: Modify the behavior of the country selector on sms quick auth

### DIFF
--- a/app/views/decidim/half_signup/quick_auth/_phone_form.html.erb
+++ b/app/views/decidim/half_signup/quick_auth/_phone_form.html.erb
@@ -1,7 +1,12 @@
 <div class="row">
   <div class="columns large-4">
     <div class="field">
-      <%= form.select :phone_country, phone_country_options(form.object.phone_country), { id: "omniauth_country", include_blank: true }, class: "country-select" %>
+      <% if !unique_country? %>
+        <%= form.select :phone_country, phone_country_options(form.object.phone_country), { id: "omniauth_country", include_blank: true }, class: "country-select" %>
+      <% else %>
+        <%= form.text_field :phone_country, value: phone_unique_country[0], class: "country-select", readonly: true, style: "padding-left: 30px; background-image: url(#{phone_unique_country[2][:data][:flag_image]}); background-repeat: no-repeat; background-position: 5px center; background-size: 20px auto;" %>
+        <%= hidden_field_tag 'phone_country_code', phone_unique_country[1] %>
+      <% end %>
     </div>
   </div>
   <div class="columns large-8">

--- a/lib/decidim/half_signup.rb
+++ b/lib/decidim/half_signup.rb
@@ -22,7 +22,7 @@ module Decidim
     # The country or countries to be selected in country selection
     # during sms verification/authentication. The default is being set to the US.
     config_accessor :default_countries do
-      [:us, :fr]
+      [:us]
     end
 
     # Configuration to enable or disable agree to the terms and condition pages

--- a/lib/decidim/half_signup.rb
+++ b/lib/decidim/half_signup.rb
@@ -22,7 +22,7 @@ module Decidim
     # The country or countries to be selected in country selection
     # during sms verification/authentication. The default is being set to the US.
     config_accessor :default_countries do
-      [:us]
+      [:us, :fr]
     end
 
     # Configuration to enable or disable agree to the terms and condition pages

--- a/spec/system/add_update_phone_number_spec.rb
+++ b/spec/system/add_update_phone_number_spec.rb
@@ -13,6 +13,7 @@ describe "Add/update phone number", type: :system do
     sign_in user
     switch_to_host(organization.host)
     visit decidim.account_path
+    allow(Decidim::HalfSignup.config).to receive(:default_countries).and_return([])
   end
 
   context "when sms_auth is not enabled" do


### PR DESCRIPTION
## 🎩 Description

This modified the behavior of the country selector in multiple ways : 
- No country by default : Actual behavior we can have every phone number available but no default selected
- One country by default : New behavior : We may have now a non-updatable input that contains our country by default
- Multiple countries by default : New behavior : Are only available for selection those who are in the list of the default_countries 

## 🔧 Changes

- [x] Addition of the new behaviors
- [x] Tests added