### PR TITLE
fix: Add a condition to check if auth settings were not enabled

### DIFF
--- a/app/views/decidim/shared/_half_signup_login_modal.html.erb
+++ b/app/views/decidim/shared/_half_signup_login_modal.html.erb
@@ -7,7 +7,7 @@
     </button>
   </div>
 
-  <% methods = current_organization.auth_setting.available_methods %>
+  <% methods = current_organization.auth_setting.available_methods unless current_organization.auth_setting.blank? %>
 
   <% if current_organization.sign_in_enabled? %>
     <% if methods.blank? %>

--- a/app/views/decidim/shared/_half_signup_login_modal.html.erb
+++ b/app/views/decidim/shared/_half_signup_login_modal.html.erb
@@ -7,7 +7,7 @@
     </button>
   </div>
 
-  <% methods = current_organization.auth_setting.available_methods unless current_organization.auth_setting.blank? %>
+  <% methods = current_organization.auth_setting&.available_methods %>
 
   <% if current_organization.sign_in_enabled? %>
     <% if methods.blank? %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -132,5 +132,6 @@ en:
         welcome: Welcome to the <br><strong>%{organization} platform!</strong>
     shared:
       half_signup_login_modal:
+        sign_up: Sign up
         close_modal: Close
         please_sign_in: Please sign in


### PR DESCRIPTION
###  🎩 Description

This fix is meant to avoid an error 500 when accessing to a budget (on this branch) without activating any auth settings from half sign_up as it is the case for now