### PR TITLE
fix: Multiple fixes to remove the partial + French translation

### DIFF
--- a/app/commands/decidim/half_signup/authenticate_user.rb
+++ b/app/commands/decidim/half_signup/authenticate_user.rb
@@ -90,7 +90,7 @@ module Decidim
 
         user = Decidim::User.find(session[:user_id])
 
-        return if check_phone_difference
+        return if check_phone_difference(user)
 
         user.update!(
           phone_number: data["phone"],
@@ -98,7 +98,7 @@ module Decidim
         )
       end
 
-      def check_phone_difference
+      def check_phone_difference(user)
         user.phone_number.present? && user.phone_number != data["phone"] && user.phone_country != data["country"]
       end
     end

--- a/app/commands/decidim/half_signup/authenticate_user.rb
+++ b/app/commands/decidim/half_signup/authenticate_user.rb
@@ -38,7 +38,6 @@ module Decidim
 
       def find_or_create_user!
         user = if sms_auth?
-                 # If we are in a test env we don't check the session
                  update_decidim_user_phone(session, data)
 
                  Decidim::User.find_by(
@@ -90,6 +89,9 @@ module Decidim
         return unless session.present? && session[:user_id].present?
 
         user = Decidim::User.find(session[:user_id])
+
+        return if user.phone_number.present? && !(user.phone_number == data["phone"] && user.phone_country == data["country"])
+
         user.update!(
           phone_number: data["phone"],
           phone_country: data["country"]

--- a/app/commands/decidim/half_signup/authenticate_user.rb
+++ b/app/commands/decidim/half_signup/authenticate_user.rb
@@ -90,12 +90,16 @@ module Decidim
 
         user = Decidim::User.find(session[:user_id])
 
-        return if user.phone_number.present? && !(user.phone_number == data["phone"] && user.phone_country == data["country"])
+        return if check_phone_difference
 
         user.update!(
           phone_number: data["phone"],
           phone_country: data["country"]
         )
+      end
+
+      def check_phone_difference
+        user.phone_number.present? && user.phone_number != data["phone"] && user.phone_country != data["country"]
       end
     end
   end

--- a/app/controllers/decidim/budgets/voting_controller.rb
+++ b/app/controllers/decidim/budgets/voting_controller.rb
@@ -19,6 +19,7 @@ module Decidim
 
       def index
         enforce_permission_to :vote, :project, project: budget.projects.first, budget: budget, workflow: current_workflow
+        session[:has_validated] = false
       end
 
       private

--- a/app/middleware/half_signup_middleware.rb
+++ b/app/middleware/half_signup_middleware.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class HalfSignupMiddleware
-  ALLOWED_PATHS = %w(/quick_auth /users /terms-and-conditions).freeze
+  ALLOWED_PATHS = %w(/quick_auth /users /terms-and-conditions /rails/active_storage).freeze
   REGEXP_PAGE = %r{/budgets/\d+/voting}
   REGEXP_VOTE = %r{/budgets/\d+/order}
 

--- a/app/middleware/half_signup_middleware.rb
+++ b/app/middleware/half_signup_middleware.rb
@@ -41,7 +41,7 @@ class HalfSignupMiddleware
   end
 
   def half_signup_user?(user)
-    user.email.include?("quick_auth") && user.name == "Unnamed user"
+    user.email.include?("quick_auth") || user.name == I18n.t("unnamed_user", scope: "decidim.half_signup.quick_auth.authenticate")
   end
 
   def sign_out_user(request)

--- a/app/views/decidim/budgets/projects/_pre_voting_budget_summary.html.erb
+++ b/app/views/decidim/budgets/projects/_pre_voting_budget_summary.html.erb
@@ -1,4 +1,7 @@
 <div class="card budget-summary" data-progress-reference data-safe-url="<%= budget_url(budget) %>">
+
+  <% methods = current_organization.auth_setting.available_methods unless current_organization.auth_setting.blank? %>
+
   <div class="card__content">
     <% if current_order_checked_out? %>
       <h2 class="heading3">
@@ -16,9 +19,16 @@
       </h2>
       <p>
         <%= description_text %>
-        <% if current_user %>
+
+        <% if methods.length === 0 || current_user %>
           <%= button_to vote_text, budget_voting_index_path, class: "button hollow button--sc pull-right", method: :get, disabled: !voting_open? %>
-        <% else %>
+        <% elsif methods.length === 1 %>
+          <% if methods.include?("email") %>
+             <%= link_to vote_text, decidim_half_signup.users_quick_auth_email_path(redirect_url: budget_voting_index_path), class: "button hollow button--sc pull-right" %>
+          <% elsif methods.include?("sms") %>
+            <%= link_to vote_text, decidim_half_signup.users_quick_auth_sms_path(redirect_url: budget_voting_index_path), class: "button hollow button--sc pull-right" %>
+          <% end %>
+      <% else %>
           <%= link_to vote_text, "#",  class: "button hollow button--sc pull-right", data: { toggle: "halfSignupLoginModal" } %>
         <% end %>
       </p>

--- a/app/views/decidim/budgets/projects/_pre_voting_budget_summary.html.erb
+++ b/app/views/decidim/budgets/projects/_pre_voting_budget_summary.html.erb
@@ -20,7 +20,7 @@
       <p>
         <%= description_text %>
 
-        <% if methods.empty? || current_user %>
+        <% if methods.blank? || current_user %>
           <%= button_to vote_text, budget_voting_index_path, class: "button hollow button--sc pull-right", method: :get, disabled: !voting_open? %>
         <% elsif methods.length == 1 %>
           <% if methods.include?("email") %>

--- a/app/views/decidim/budgets/projects/_pre_voting_budget_summary.html.erb
+++ b/app/views/decidim/budgets/projects/_pre_voting_budget_summary.html.erb
@@ -1,6 +1,6 @@
 <div class="card budget-summary" data-progress-reference data-safe-url="<%= budget_url(budget) %>">
 
-  <% methods = current_organization.auth_setting.available_methods unless current_organization.auth_setting.blank? %>
+  <% methods = current_organization.auth_setting&.available_methods %>
 
   <div class="card__content">
     <% if current_order_checked_out? %>
@@ -20,16 +20,16 @@
       <p>
         <%= description_text %>
 
-        <% if methods.length === 0 || current_user %>
+        <% if methods.empty? || current_user %>
           <%= button_to vote_text, budget_voting_index_path, class: "button hollow button--sc pull-right", method: :get, disabled: !voting_open? %>
-        <% elsif methods.length === 1 %>
+        <% elsif methods.length == 1 %>
           <% if methods.include?("email") %>
-             <%= link_to vote_text, decidim_half_signup.users_quick_auth_email_path(redirect_url: budget_voting_index_path), class: "button hollow button--sc pull-right" %>
+            <%= link_to vote_text, decidim_half_signup.users_quick_auth_email_path(redirect_url: budget_voting_index_path), class: "button hollow button--sc pull-right" %>
           <% elsif methods.include?("sms") %>
             <%= link_to vote_text, decidim_half_signup.users_quick_auth_sms_path(redirect_url: budget_voting_index_path), class: "button hollow button--sc pull-right" %>
           <% end %>
-      <% else %>
-          <%= link_to vote_text, "#",  class: "button hollow button--sc pull-right", data: { toggle: "halfSignupLoginModal" } %>
+        <% else %>
+          <%= link_to vote_text, "#", class: "button hollow button--sc pull-right", data: { toggle: "halfSignupLoginModal" } %>
         <% end %>
       </p>
     <% end %>

--- a/app/views/decidim/shared/_half_signup_login_modal.html.erb
+++ b/app/views/decidim/shared/_half_signup_login_modal.html.erb
@@ -7,7 +7,7 @@
     </button>
   </div>
 
-  <% methods = current_organization.auth_setting.available_methods %>
+  <% methods = current_organization.auth_setting&.available_methods %>
 
   <% if current_organization.sign_in_enabled? %>
     <% if methods.blank? %>

--- a/app/views/decidim/shared/_half_signup_login_modal.html.erb
+++ b/app/views/decidim/shared/_half_signup_login_modal.html.erb
@@ -66,16 +66,7 @@
                 </div>
               </div>
             </div>
-            <div class="half-signup-methods-item half-signup-methods-item-or">
-              <%= t("or", scope: "decidim.half_signup.quick_auth.options")%>
-            </div>
-            <div class="row margin-1">
-              <div class="columns medium-10 small-centered">
-                <div class="half-signup-methods-item">
-                  <%= link_to t("classic_connection", scope: "decidim.half_signup.quick_auth.options"), decidim.new_user_session_path(redirect_url: redirect_path), class: "button expanded" %>
-                </div>
-              </div>
-            </div>
+
           </div>
         </div>
       </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -132,5 +132,6 @@ en:
         welcome: Welcome to the <br><strong>%{organization} platform!</strong>
     shared:
       half_signup_login_modal:
+        sign_up: Sign up
         close_modal: Close
         please_sign_in: Please sign in

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -25,7 +25,7 @@ en:
         pre_voting_budget_summary:
           sign_in_first: You need to sign in to start voting.
       voting:
-        phone_number_required×: You need to add your phone number to vote.
+        phone_number_required: You need to add your phone number to vote.
         index:
           sign_in_first: You need to sign in to start voting.
     components:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1,0 +1,118 @@
+---
+fr:
+  activemodel:
+    attributes:
+      auth_setting:
+        enable_partial_email_signup: Activer l'inscription partielle par vérification de l'e-mail
+        enable_partial_sms_signup: Activer l'inscription partielle par vérification SMS
+      sms_auth:
+        phone_country: Indicatif du pays
+        phone_number: Numéro de téléphone
+  decidim:
+    account:
+      change_phone_number:
+        add: Ajouter votre numéro de téléphone
+        update: Mettre à jour votre numéro de téléphone
+    budgets:
+      projects:
+        budget_confirm:
+          half_signup:
+            warning: Cette action vous déconnectera à la fin du processus et vous ne pourrez pas modifier votre vote
+        cancel_voting_modal:
+          quick_auth_warning: Cette action vous déconnectera à la fin du processus
+        pre_voting_budget_summary:
+          sign_in_first: Vous devez vous connecter pour commencer à voter.
+      voting:
+        phone_number_required: Vous devez ajouter votre numéro de téléphone pour voter.
+        index:
+          sign_in_first: Vous devez vous connecter pour commencer à voter.
+    components:
+      half_signup:
+        name: Inscription Partielle
+    half_signup:
+      admin:
+        auth_settings:
+          description: Le module fournit quelques paramètres via des configurations de module pouvant être définies depuis le code. Utilisez l'exemple de code suivant dans un initialiseur avec les commentaires qui expliquent ce que fait chaque paramètre.
+          edit:
+            title: Module d'inscription partielle
+            update: Mettre à jour
+          email:
+            help_text: Cette option permet aux utilisateurs de s'inscrire et de se connecter à la plateforme en utilisant leur adresse e-mail en recevant une vérification par e-mail.
+          sms:
+            help_text: Cette option permet aux utilisateurs de s'inscrire et de se connecter à la plateforme en utilisant leur adresse e-mail en recevant un code de vérification par SMS.
+          title: Paramètres disponibles via le code
+      menu:
+        auth_settings: Paramètres d'authentification
+      quick_auth:
+        another_method: Utiliser une autre méthode
+        authenticate:
+          unnamed_user: Utilisateur anonyme
+        authenticate_user:
+          error: La vérification a échoué. Veuillez réessayer.
+          phone_exist: Ce numéro de téléphone est lié à un autre compte. Veuillez utiliser un autre numéro de téléphone, ou contacter l'administration.
+          signed_in: Connexion réussie.
+          threshold_exceeded: Trop de tentatives échouées. Veuillez réessayer plus tard.
+          unauthorized: Vous n'êtes pas autorisé à effectuer cette action.
+          updated: Compte utilisateur mis à jour avec succès.
+        back: Retour au compte
+        development_hint:
+          hint_notification: "(Ce message n'apparaît qu'en mode développement)"
+          verification_code: 'Le code de vérification est : '
+        email:
+          enter_email: 'Veuillez saisir votre e-mail :'
+          instruction: L'adresse e-mail sera votre clé d'accès à la plateforme. Un e-mail sera envoyé à votre adresse e-mail chaque fois que vous souhaitez vous connecter. Si vous avez déjà un compte sur cette plateforme, veuillez saisir cet e-mail pour vous connecter.
+        email_form:
+          submit: Envoyer le code
+        email_option:
+          email: E-mail
+        email_verification:
+          content: Confirmez votre adresse e-mail en saisissant le code de connexion ci-dessous dans le champ prévu sur le service.
+          details: 'Votre code de connexion est :'
+          error: Une erreur s'est produite lors de la tentative d'envoi de la vérification à votre adresse e-mail, veuillez réessayer. Si l'erreur persiste, veuillez contacter le support de la plateforme pour obtenir de l'aide supplémentaire.
+          subject: 'Votre code de connexion est : %{verification}'
+          success: Code de vérification envoyé à %{email}.
+          welcome: Bienvenue sur la plateforme !
+        enter_code: 'Veuillez saisir le code :'
+        instruction: Vous devriez avoir reçu le code à %{contact_info}
+        options:
+          classic_connection: Se connecter en utilisant la méthode classique
+          email: À votre e-mail
+          not_allowed: Vous n'êtes pas autorisé à effectuer cette action.
+          or: OU
+          select: Veuillez sélectionner comment vous souhaitez vous connecter.
+          send_code_to: 'Devrions-nous envoyer le code à :'
+          sms: À votre téléphone
+          title: Vous devez vous authentifier pour voter.
+          with_email: Avec votre e-mail
+          with_sms: Avec votre téléphone
+        phone_form:
+          submit: Envoyer le code
+        resend_code:
+          not_allowed: Veuillez attendre au moins 1 minute avant de renvoyer le code.
+        sms:
+          enter_phone: 'Veuillez saisir votre numéro de téléphone :'
+          instruction: Le numéro de téléphone sera votre clé d'accès à la plateforme. À moins que vous n'ajoutiez un mot de passe à votre compte, un SMS sera envoyé à votre numéro de téléphone chaque fois que vous souhaitez vous connecter.
+        sms_option:
+          sms: SMS
+        sms_verification:
+          invalid_from_number: Le numéro de l'expéditeur n'est pas correctement configuré ou n'est pas capable d'envoyer des messages. Veuillez contacter le support de la plateforme pour obtenir de l'aide supplémentaire.
+          invalid_geo_permission: Le système n'est pas configuré pour envoyer des messages dans votre pays. Veuillez contacter le support de la plateforme pour obtenir de l'aide supplémentaire.
+          invalid_to_number: Le numéro de téléphone que vous avez fourni n'est pas correct. Veuillez vérifier que vous avez entré correctement votre numéro de téléphone.
+          success: Code de vérification envoyé à %{phone}.
+          text_message: Utilisez le code %{verification} pour vous connecter à la plateforme.
+          unknown: Une erreur s'est produite et a été journalisée, veuillez réessayer. Si l'erreur persiste, veuillez contacter le support de la plateforme pour obtenir de l'aide supplémentaire.
+        verify:
+          have_not_received: Vous n'avez pas reçu le code ?
+          incorrect_email: "(adresse incorrecte ?)"
+          incorrect_phone: "(numéro de téléphone incorrect ?)"
+          inputs:
+            one: Premier chiffre
+            other: chiffre %{count}
+          resend_code: Renvoyer.
+          submit: Vérifier
+        welcome: Bienvenue sur la <br><strong>plateforme %{organization} !</strong>
+    shared:
+      half_signup_login_modal:
+        sign_up: S'inscrire
+        close_modal: Fermer
+        please_sign_in: Veuillez vous connecter

--- a/lib/decidim/budgets_booth/voting_support.rb
+++ b/lib/decidim/budgets_booth/voting_support.rb
@@ -62,12 +62,17 @@ module Decidim
       end
 
       def ensure_user_phone_number
-        return true if current_user.try(:phone_number).present?
+        session[:user_id] = current_user.id if current_user.id.present? && current_user.email.exclude?("quick-auth")
 
-        session[:user_id] = current_user.id
-        sign_out current_user
-        flash[:warning] = t("decidim.budgets.voting.phone_number_required")
-        redirect_to decidim_half_signup.users_quick_auth_sms_path
+        validate_user_session if session[:has_validated].blank? || !session[:has_validated]
+      end
+
+      def validate_user_session
+        if current_user.email.exclude?("quick_auth")
+          sign_out current_user
+          flash[:warning] = t("decidim.budgets.voting.phone_number_required")
+          redirect_to decidim_half_signup.users_quick_auth_sms_path
+        end
       end
 
       # maximum_budgets_to_vote_on is being set by the admin. the default is zero, which means users can

--- a/lib/decidim/budgets_booth/voting_support.rb
+++ b/lib/decidim/budgets_booth/voting_support.rb
@@ -69,6 +69,7 @@ module Decidim
 
       def validate_user_session
         if current_user.email.exclude?("quick_auth")
+          session[:has_validated] = true
           sign_out current_user
           flash[:warning] = t("decidim.budgets.voting.phone_number_required")
           redirect_to decidim_half_signup.users_quick_auth_sms_path


### PR DESCRIPTION
## 🎩 Description

This PR fixes the fact that a partial was displayed because automatically we had two methods of authentication (classic way and half_signup) but that is now changed as we don't want to connect in a classical way but that does imply some internal changes into the functionality itself as it was configured by default not to "repeat" verification for a decidim user but as we want to verify phone number each time it's important to get rid of it 

This also adds a french translation for the module as it didn't exist since now

## 🔧 Changes

- [x] Deletion of the partial if only one half signup method
- [x] Verify each vote the phone_number of the user to make sure that the vote is official
- [x] Change the internal behavior of the verification
- [x] Addition of a french translation

⚠️ To test this PR you must add budgets booth to your global gemfile before generating your dev-app

`gem "decidim-budgets_booth", github: "Pipeline-to-Power/decidim-module-ptp", branch: "main"`