### PR TITLE
fix: Add manifest to ignored links in the middleware

### DIFF
--- a/app/middleware/half_signup_middleware.rb
+++ b/app/middleware/half_signup_middleware.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class HalfSignupMiddleware
-  ALLOWED_PATHS = %w(/quick_auth /users /terms-and-conditions /rails/active_storage).freeze
+  ALLOWED_PATHS = %w(/quick_auth /users /terms-and-conditions /rails/active_storage /manifest).freeze
   REGEXP_PAGE = %r{/budgets/\d+/voting}
   REGEXP_VOTE = %r{/budgets/\d+/order}
 


### PR DESCRIPTION
## 🎩 Description

This adds the /manifest to the middleware as it resulted in production to disconnect few users automatically