### PR TITLE
fix: User cannot vote without verifying phone number at least once

### DIFF
--- a/app/commands/decidim/half_signup/authenticate_user.rb
+++ b/app/commands/decidim/half_signup/authenticate_user.rb
@@ -92,6 +92,8 @@ module Decidim
 
         return if check_phone_difference(user)
 
+        session[:has_validated] = true
+
         user.update!(
           phone_number: data["phone"],
           phone_country: data["country"]

--- a/lib/decidim/budgets_booth/voting_support.rb
+++ b/lib/decidim/budgets_booth/voting_support.rb
@@ -62,9 +62,16 @@ module Decidim
       end
 
       def ensure_user_phone_number
+        return unless current_user
+
         session[:user_id] = current_user.id if current_user.id.present? && current_user.email.exclude?("quick-auth")
 
-        validate_user_session if session[:has_validated].blank? || !session[:has_validated]
+        return validate_user_session if session[:has_validated].blank? || !session[:has_validated]
+
+        if current_user.phone_number.blank?
+          sign_out current_user
+          redirect_to decidim_half_signup.users_quick_auth_sms_path
+        end
       end
 
       def validate_user_session


### PR DESCRIPTION
#### :tophat: Description

Minor fix - Fix an issue where it resulted that with a really specific behavior the user could vote without validating her phone number 
Minor fix - Fix of an issue that when a user connects to a decidim account that already contain a phone number she doesn't have to validate an other time her phone number in order to vote


