### PR TITLE
fix: Ensure compatibility between SMS and EMAIL methods using the middleware

### DIFF
--- a/app/middleware/half_signup_middleware.rb
+++ b/app/middleware/half_signup_middleware.rb
@@ -49,7 +49,7 @@ class HalfSignupMiddleware
   end
 
   def half_signup_user?(user)
-    user.email.include?("quick_auth") || user.name == I18n.t("unnamed_user", scope: "decidim.half_signup.quick_auth.authenticate")
+    user.email.include?("quick_auth") || user.name == I18n.t("unnamed_user", scope: "decidim.half_signup.quick_auth.authenticate", locale: user.locale)
   end
 
   def sign_out_user(request)

--- a/app/views/decidim/half_signup/quick_auth/_email_option.html.erb
+++ b/app/views/decidim/half_signup/quick_auth/_email_option.html.erb
@@ -7,9 +7,9 @@
   </div>
   <div class="button-wrapper">
     <% if modify_button_text %>
-      <%= link_to t("with_email", scope: "decidim.half_signup.quick_auth.options"), decidim_half_signup.users_quick_auth_email_path, redirect_url: redirect_path, class: "button expanded" %>
+      <%= link_to t("with_email", scope: "decidim.half_signup.quick_auth.options"), decidim_half_signup.users_quick_auth_email_path(redirect_url: redirect_path), class: "button expanded" %>
     <% else %>
-      <%= link_to t("email", scope: "decidim.half_signup.quick_auth.options"), decidim_half_signup.users_quick_auth_email_path, redirect_url: redirect_path, class: "button expanded" %>
+      <%= link_to t("email", scope: "decidim.half_signup.quick_auth.options"), decidim_half_signup.users_quick_auth_email_path(redirect_url: redirect_path), class: "button expanded" %>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
### 🎩 Description

This PR has been made to ensure the compatibility between the email and sms methods (individually and combined) to make sure that it is usable in every method possible without blocking the user or worse, crashing the app

### **⚠️ 🚨 This branch is actually not compatible with the zip code feature of budgets booth using an _half signup account_ because of the fact that the feature has been totally made to be used with a decidim account and so comes totally beyond the utility of the Half Signup middleware that we developed**

### 🔧 How to test

- Access Backoffice
- Enable HalfSignup methods (both of them or individually)
- Configure your budgets so you can be sure that you will not be blocked because of a wrong seeded config.
- Access the budget in the front office

##### ✂️ Half Signup account
- Click to vote
- Make sure you are redirected
- Put a random phone number (SMS method case)
- Put a random email (EMAIL method case)
- Follow the given instructions
- Access the budgets booth page
- Refresh, Filter and go through projects to make sure you are not disconnected
- Leave the page by cancelling the vote and check that you are disconnected
- Make sure you are logged out
- Make sure you can vote properly

##### 🇪🇸 Decidim Account
- Log in as a decidim user
- Click to vote
- Make sure even if the activated that you're not redirected to the email confirmation (totally counterproductive regarding the UX)
- Put a phone number (If sms method is enabled)
- Verify that you are directly redirected to the budget (if sms method is disabled)
- Access the budgets booth page
- Refresh, Filter and go through projects to make sure you are not disconnected
- Leave the page by cancelling the vote
- You mustn't be disconnected
- Try to reaccess the same budget or another one
- Make sure you are redirected to the quick_auth page before accessing again to the vote (if sms method is enabled)