### PR TITLE
Fix: SMS gateway service initialize

### DIFF
--- a/app/commands/decidim/half_signup/send_verification.rb
+++ b/app/commands/decidim/half_signup/send_verification.rb
@@ -46,7 +46,7 @@ module Decidim
 
             Decidim.config.sms_gateway_service.constantize.new(
               phone_number,
-              I18n.t("text_message", scope: "decidim.half_signup.quick_auth.sms_verification", verification: verification_code),
+              verification_code,
               **gateway_context
             )
           end

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -8,3 +8,4 @@ ignore_unused:
 
 ignore_missing:
   - decidim.participatory_processes.scopes.global
+  - Decidim::Verifications::Sms::ExampleGateway

--- a/spec/commands/decidim/half_signup/send_verification_spec.rb
+++ b/spec/commands/decidim/half_signup/send_verification_spec.rb
@@ -35,7 +35,7 @@ describe Decidim::HalfSignup::SendVerification, type: :command do
         allow(form).to receive(:valid?).and_return(false)
       end
 
-      it "broadcasts :invlid" do
+      it "broadcasts :invalid" do
         expect(subject).to broadcast(:invalid)
         expect(Decidim::HalfSignup::VerificationCodeMailer).not_to receive(:call)
       end
@@ -111,11 +111,11 @@ describe Decidim::HalfSignup::SendVerification, type: :command do
       context "when another gateway configured" do
         let(:foo_gateway) do
           Class.new do
-            attr_reader :number, :message, :context
+            attr_reader :number, :code, :context
 
-            def initialize(number, message, context = {})
+            def initialize(number, code, context = {})
               @number = number
-              @message = message
+              @code = code
               @context = context
             end
 
@@ -137,7 +137,7 @@ describe Decidim::HalfSignup::SendVerification, type: :command do
 
         it "sets the correct values" do
           expect(gateway.number).to eq("+358#{phone_number}")
-          expect(gateway.message).to eq("Use code #{verification} to sign in to the platform.")
+          expect(gateway.code).to eq(verification)
           expect(gateway.context).to eq({})
         end
 


### PR DESCRIPTION
Don't initialize the SMS gateway services with a message but with the verification code as originally specified in `Decidim::Verifications::Sms::ExampleGateway`