### PR TITLE
fix: SMS vote concurrency

### DIFF
--- a/app/commands/decidim/half_signup/authenticate_user.rb
+++ b/app/commands/decidim/half_signup/authenticate_user.rb
@@ -16,6 +16,8 @@ module Decidim
         transaction do
           user = find_or_create_user!
         end
+
+        Rails.logger.debug { "User authenticate: #{user.inspect}" }
         return broadcast(:ok, user) if user.present?
 
         broadcast(:invalid, I18n.t("error", scope: "decidim.half_signup.quick_auth.authenticate_user"))

--- a/app/commands/decidim/half_signup/authenticate_user.rb
+++ b/app/commands/decidim/half_signup/authenticate_user.rb
@@ -13,7 +13,9 @@ module Decidim
         return broadcast(:invalid, verification_failed) unless validate!
 
         user = find_or_create_user!
-        broadcast(:ok, user)
+        return broadcast(:ok, user) if user.present?
+
+        broadcast(:invalid, I18n.t("error", scope: "decidim.half_signup.quick_auth.authenticate_user"))
       end
 
       private
@@ -37,39 +39,58 @@ module Decidim
       end
 
       def find_or_create_user!
-        user = if sms_auth?
-                 if session.present? && session[:user_id].present?
-                   existing_user = update_decidim_user_phone(session, data)
+        ActiveRecord::Base.transaction do
+          user = if sms_auth?
+                   if session.present? && session[:user_id].present?
+                     existing_user = update_decidim_user_phone(session, data)
 
-                   existing_user.presence || find_user_by_phone_country(data)
+                     existing_user.presence || find_user_by_phone_country(data)
+                   else
+                     find_user_by_phone_country(data)
+                   end
                  else
-                   find_user_by_phone_country(data)
+                   Decidim::User.find_by(
+                     email: data["email"],
+                     organization: form.organization
+                   )
                  end
-               else
-                 Decidim::User.find_by(
-                   email: data["email"],
-                   organization: form.organization
-                 )
-               end
 
-        return user if user.present?
+          return user if user.present?
 
-        generated_password = SecureRandom.hex
-        Decidim::User.create! do |record|
-          record.name = I18n.t("unnamed_user", scope: "decidim.half_signup.quick_auth.authenticate")
-          record.nickname = UserBaseEntity.nicknamize(record.name)
-          record.email = data["email"] || generate_email(data["country"], data["phone"])
-          record.password = generated_password
-          record.password_confirmation = generated_password
+          generated_password = SecureRandom.hex
 
-          record.skip_confirmation!
+          # Use a database lock to ensure atomicity
+          Decidim::User.with_lock do
+            user = if sms_auth?
+                     find_user_by_phone_country(data)
+                   else
+                     Decidim::User.find_by(
+                       email: data["email"],
+                       organization: form.organization
+                     )
+                   end
 
-          record.phone_number = data["phone"]
-          record.phone_country = data["country"]
-          record.tos_agreement = "1"
-          record.organization = form.organization
-          record.accepted_tos_version = Time.current unless Decidim::HalfSignup.show_tos_page_after_signup
-          record.locale = form.current_locale
+            return user if user.present?
+
+            Decidim::User.create! do |record|
+              record.name = I18n.t("unnamed_user", scope: "decidim.half_signup.quick_auth.authenticate")
+              record.nickname = UserBaseEntity.nicknamize("#{record.name}_#{rand(1000)}")
+              record.email = data["email"].presence || generate_email(data["country"], data["phone"])
+              record.password = generated_password
+              record.password_confirmation = generated_password
+
+              record.skip_confirmation!
+
+              record.phone_number = data["phone"]
+              record.phone_country = data["country"]
+              record.tos_agreement = "1"
+              record.organization = form.organization
+              record.accepted_tos_version = Time.current unless Decidim::HalfSignup.show_tos_page_after_signup
+              record.locale = form.current_locale
+            end
+          end
+        rescue ActiveRecord::RecordInvalid
+          nil
         end
       end
 

--- a/app/commands/decidim/half_signup/authenticate_user.rb
+++ b/app/commands/decidim/half_signup/authenticate_user.rb
@@ -57,8 +57,8 @@ module Decidim
         generated_password = SecureRandom.hex
         Decidim::User.create! do |record|
           record.name = I18n.t("unnamed_user", scope: "decidim.half_signup.quick_auth.authenticate")
-          record.nickname = UserBaseEntity.nicknamize(record.name)
-          record.email = data["email"] || generate_email(data["country"], data["phone"])
+          record.nickname = UserBaseEntity.nicknamize("#{record.name}_#{SecureRandom.hex(4)}")
+          record.email = data["email"].presence || generate_email(data["country"], data["phone"])
           record.password = generated_password
           record.password_confirmation = generated_password
 

--- a/app/commands/decidim/half_signup/authenticate_user.rb
+++ b/app/commands/decidim/half_signup/authenticate_user.rb
@@ -13,9 +13,7 @@ module Decidim
         return broadcast(:invalid, verification_failed) unless validate!
 
         user = find_or_create_user!
-        return broadcast(:ok, user) if user.present?
-
-        broadcast(:invalid, I18n.t("error", scope: "decidim.half_signup.quick_auth.authenticate_user"))
+        broadcast(:ok, user)
       end
 
       private
@@ -39,58 +37,39 @@ module Decidim
       end
 
       def find_or_create_user!
-        ActiveRecord::Base.transaction do
-          user = if sms_auth?
-                   if session.present? && session[:user_id].present?
-                     existing_user = update_decidim_user_phone(session, data)
+        user = if sms_auth?
+                 if session.present? && session[:user_id].present?
+                   existing_user = update_decidim_user_phone(session, data)
 
-                     existing_user.presence || find_user_by_phone_country(data)
-                   else
-                     find_user_by_phone_country(data)
-                   end
+                   existing_user.presence || find_user_by_phone_country(data)
                  else
-                   Decidim::User.find_by(
-                     email: data["email"],
-                     organization: form.organization
-                   )
+                   find_user_by_phone_country(data)
                  end
+               else
+                 Decidim::User.find_by(
+                   email: data["email"],
+                   organization: form.organization
+                 )
+               end
 
-          return user if user.present?
+        return user if user.present?
 
-          generated_password = SecureRandom.hex
+        generated_password = SecureRandom.hex
+        Decidim::User.create! do |record|
+          record.name = I18n.t("unnamed_user", scope: "decidim.half_signup.quick_auth.authenticate")
+          record.nickname = UserBaseEntity.nicknamize(record.name)
+          record.email = data["email"] || generate_email(data["country"], data["phone"])
+          record.password = generated_password
+          record.password_confirmation = generated_password
 
-          # Use a database lock to ensure atomicity
-          Decidim::User.with_lock do
-            user = if sms_auth?
-                     find_user_by_phone_country(data)
-                   else
-                     Decidim::User.find_by(
-                       email: data["email"],
-                       organization: form.organization
-                     )
-                   end
+          record.skip_confirmation!
 
-            return user if user.present?
-
-            Decidim::User.create! do |record|
-              record.name = I18n.t("unnamed_user", scope: "decidim.half_signup.quick_auth.authenticate")
-              record.nickname = UserBaseEntity.nicknamize("#{record.name}_#{rand(1000)}")
-              record.email = data["email"].presence || generate_email(data["country"], data["phone"])
-              record.password = generated_password
-              record.password_confirmation = generated_password
-
-              record.skip_confirmation!
-
-              record.phone_number = data["phone"]
-              record.phone_country = data["country"]
-              record.tos_agreement = "1"
-              record.organization = form.organization
-              record.accepted_tos_version = Time.current unless Decidim::HalfSignup.show_tos_page_after_signup
-              record.locale = form.current_locale
-            end
-          end
-        rescue ActiveRecord::RecordInvalid
-          nil
+          record.phone_number = data["phone"]
+          record.phone_country = data["country"]
+          record.tos_agreement = "1"
+          record.organization = form.organization
+          record.accepted_tos_version = Time.current unless Decidim::HalfSignup.show_tos_page_after_signup
+          record.locale = form.current_locale
         end
       end
 

--- a/app/commands/decidim/half_signup/authenticate_user.rb
+++ b/app/commands/decidim/half_signup/authenticate_user.rb
@@ -12,8 +12,13 @@ module Decidim
         return broadcast(:invalid) unless form.valid?
         return broadcast(:invalid, verification_failed) unless validate!
 
-        user = find_or_create_user!
-        broadcast(:ok, user)
+        user = nil
+        transaction do
+          user = find_or_create_user!
+        end
+        return broadcast(:ok, user) if user.present?
+
+        broadcast(:invalid, I18n.t("error", scope: "decidim.half_signup.quick_auth.authenticate_user"))
       end
 
       private

--- a/app/controllers/decidim/half_signup/quick_auth_controller.rb
+++ b/app/controllers/decidim/half_signup/quick_auth_controller.rb
@@ -9,6 +9,7 @@ module Decidim
       before_action :ensure_authorized, only: [:email, :options]
 
       skip_before_action :verify_authenticity_token, only: [:authenticate] if Decidim::HalfSignup.skip_csrf
+      rescue_from ActionController::InvalidAuthenticityToken, with: :handle_invalid_authenticity_token
 
       def sms
         ensure_enabled_auth("sms")
@@ -221,6 +222,11 @@ module Decidim
       def reset_attempts
         auth_session["attempts"] = 0
         auth_session["last_attempt"] = nil
+      end
+
+      def handle_invalid_authenticity_token
+        flash[:alert] = I18n.t("authenticity_token", scope: "decidim.half_signup.quick_auth.authenticate_user")
+        redirect_back(fallback_location: decidim.root_path)
       end
     end
   end

--- a/app/controllers/decidim/half_signup/quick_auth_controller.rb
+++ b/app/controllers/decidim/half_signup/quick_auth_controller.rb
@@ -7,6 +7,7 @@ module Decidim
       include Decidim::HalfSignup::PartialSignupSettings
 
       before_action :ensure_authorized, only: [:email, :options]
+      skip_before_action :verify_authenticity_token, only: [:authenticate], if: -> { Decidim::HalfSignup.skip_csrf? }
 
       def sms
         ensure_enabled_auth("sms")

--- a/app/controllers/decidim/half_signup/quick_auth_controller.rb
+++ b/app/controllers/decidim/half_signup/quick_auth_controller.rb
@@ -7,7 +7,8 @@ module Decidim
       include Decidim::HalfSignup::PartialSignupSettings
 
       before_action :ensure_authorized, only: [:email, :options]
-      skip_before_action :verify_authenticity_token, only: [:authenticate], if: -> { Decidim::HalfSignup.skip_csrf? }
+
+      skip_before_action :verify_authenticity_token, only: [:authenticate] if Decidim::HalfSignup.skip_csrf
 
       def sms
         ensure_enabled_auth("sms")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,9 +28,9 @@ en:
         checkout:
           error: An error occurred while trying to process your vote. Please try again.
           success: Your vote has been successfully registered.
-        phone_number_required: You need to add your phone number to vote.
         index:
           sign_in_first: You need to sign in to start voting.
+        phone_number_required: You need to add your phone number to vote.
     components:
       half_signup:
         name: HalfSignup
@@ -57,6 +57,8 @@ en:
         authenticate:
           unnamed_user: Unnamed user
         authenticate_user:
+          authenticity_token: Your session has expired. Please try submitting the
+            form again.
           error: Verification failed. Please try again.
           phone_exist: This phone number is bined to another account. Please use another
             phone number, or contact administration.
@@ -135,6 +137,6 @@ en:
         welcome: Welcome to the <br><strong>%{organization} platform!</strong>
     shared:
       half_signup_login_modal:
-        sign_up: Sign up
         close_modal: Close
         please_sign_in: Please sign in
+        sign_up: Sign up

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -3,8 +3,10 @@ fr:
   activemodel:
     attributes:
       auth_setting:
-        enable_partial_email_signup: Activer l'inscription partielle par vérification de l'e-mail
-        enable_partial_sms_signup: Activer l'inscription partielle par vérification SMS
+        enable_partial_email_signup: Activer l'inscription partielle par vérification
+          de l'e-mail
+        enable_partial_sms_signup: Activer l'inscription partielle par vérification
+          SMS
       sms_auth:
         phone_country: Indicatif du pays
         phone_number: Numéro de téléphone
@@ -17,32 +19,41 @@ fr:
       projects:
         budget_confirm:
           half_signup:
-            warning: Cette action vous déconnectera à la fin du processus et vous ne pourrez pas modifier votre vote
+            warning: Cette action vous déconnectera à la fin du processus et vous
+              ne pourrez pas modifier votre vote
         cancel_voting_modal:
           quick_auth_warning: Cette action vous déconnectera à la fin du processus
         pre_voting_budget_summary:
           sign_in_first: Vous devez vous connecter pour commencer à voter.
       voting:
         checkout:
-          error: Une erreur s'est produite lors de la tentative de traitement de votre vote. Veuillez réessayer.
+          error: Une erreur s'est produite lors de la tentative de traitement de votre
+            vote. Veuillez réessayer.
           success: Votre vote a été enregistré avec succès.
-        phone_number_required: Vous devez ajouter votre numéro de téléphone pour voter.
         index:
           sign_in_first: Vous devez vous connecter pour commencer à voter.
+        phone_number_required: Vous devez ajouter votre numéro de téléphone pour voter.
     components:
       half_signup:
         name: Inscription Partielle
     half_signup:
       admin:
         auth_settings:
-          description: Le module fournit quelques paramètres via des configurations de module pouvant être définies depuis le code. Utilisez l'exemple de code suivant dans un initialiseur avec les commentaires qui expliquent ce que fait chaque paramètre.
+          description: Le module fournit quelques paramètres via des configurations
+            de module pouvant être définies depuis le code. Utilisez l'exemple de
+            code suivant dans un initialiseur avec les commentaires qui expliquent
+            ce que fait chaque paramètre.
           edit:
             title: Module d'inscription partielle
             update: Mettre à jour
           email:
-            help_text: Cette option permet aux utilisateurs de s'inscrire et de se connecter à la plateforme en utilisant leur adresse e-mail en recevant une vérification par e-mail.
+            help_text: Cette option permet aux utilisateurs de s'inscrire et de se
+              connecter à la plateforme en utilisant leur adresse e-mail en recevant
+              une vérification par e-mail.
           sms:
-            help_text: Cette option permet aux utilisateurs de s'inscrire et de se connecter à la plateforme en utilisant leur adresse e-mail en recevant un code de vérification par SMS.
+            help_text: Cette option permet aux utilisateurs de s'inscrire et de se
+              connecter à la plateforme en utilisant leur adresse e-mail en recevant
+              un code de vérification par SMS.
           title: Paramètres disponibles via le code
       menu:
         auth_settings: Paramètres d'authentification
@@ -51,10 +62,14 @@ fr:
         authenticate:
           unnamed_user: Utilisateur anonyme
         authenticate_user:
+          authenticity_token: Votre session a expiré, veuillez à nouveau remplir le
+            formulaire.
           error: La vérification a échoué. Veuillez réessayer.
-          phone_exist: Ce numéro de téléphone est lié à un autre compte. Veuillez utiliser un autre numéro de téléphone, ou contacter l'administration.
+          phone_exist: Ce numéro de téléphone est lié à un autre compte. Veuillez
+            utiliser un autre numéro de téléphone, ou contacter l'administration.
           signed_in: Connexion réussie.
-          threshold_exceeded: Trop de tentatives échouées. Veuillez réessayer plus tard.
+          threshold_exceeded: Trop de tentatives échouées. Veuillez réessayer plus
+            tard.
           unauthorized: Vous n'êtes pas autorisé à effectuer cette action.
           updated: Compte utilisateur mis à jour avec succès.
         back: Retour au compte
@@ -63,15 +78,21 @@ fr:
           verification_code: 'Le code de vérification est : '
         email:
           enter_email: 'Veuillez saisir votre e-mail :'
-          instruction: L'adresse e-mail sera votre clé d'accès à la plateforme. Un e-mail sera envoyé à votre adresse e-mail chaque fois que vous souhaitez vous connecter. Si vous avez déjà un compte sur cette plateforme, veuillez saisir cet e-mail pour vous connecter.
+          instruction: L'adresse e-mail sera votre clé d'accès à la plateforme. Un
+            e-mail sera envoyé à votre adresse e-mail chaque fois que vous souhaitez
+            vous connecter. Si vous avez déjà un compte sur cette plateforme, veuillez
+            saisir cet e-mail pour vous connecter.
         email_form:
           submit: Envoyer le code
         email_option:
           email: E-mail
         email_verification:
-          content: Confirmez votre adresse e-mail en saisissant le code de connexion ci-dessous dans le champ prévu sur le service.
+          content: Confirmez votre adresse e-mail en saisissant le code de connexion
+            ci-dessous dans le champ prévu sur le service.
           details: 'Votre code de connexion est :'
-          error: Une erreur s'est produite lors de la tentative d'envoi de la vérification à votre adresse e-mail, veuillez réessayer. Si l'erreur persiste, veuillez contacter le support de la plateforme pour obtenir de l'aide supplémentaire.
+          error: Une erreur s'est produite lors de la tentative d'envoi de la vérification
+            à votre adresse e-mail, veuillez réessayer. Si l'erreur persiste, veuillez
+            contacter le support de la plateforme pour obtenir de l'aide supplémentaire.
           subject: 'Votre code de connexion est : %{verification}'
           success: Code de vérification envoyé à %{email}.
           welcome: Bienvenue sur la plateforme !
@@ -94,16 +115,28 @@ fr:
           not_allowed: Veuillez attendre au moins 1 minute avant de renvoyer le code.
         sms:
           enter_phone: 'Veuillez saisir votre numéro de téléphone :'
-          instruction: Le numéro de téléphone sera votre clé d'accès à la plateforme. À moins que vous n'ajoutiez un mot de passe à votre compte, un SMS sera envoyé à votre numéro de téléphone chaque fois que vous souhaitez vous connecter.
+          instruction: Le numéro de téléphone sera votre clé d'accès à la plateforme.
+            À moins que vous n'ajoutiez un mot de passe à votre compte, un SMS sera
+            envoyé à votre numéro de téléphone chaque fois que vous souhaitez vous
+            connecter.
         sms_option:
           sms: SMS
         sms_verification:
-          invalid_from_number: Le numéro de l'expéditeur n'est pas correctement configuré ou n'est pas capable d'envoyer des messages. Veuillez contacter le support de la plateforme pour obtenir de l'aide supplémentaire.
-          invalid_geo_permission: Le système n'est pas configuré pour envoyer des messages dans votre pays. Veuillez contacter le support de la plateforme pour obtenir de l'aide supplémentaire.
-          invalid_to_number: Le numéro de téléphone que vous avez fourni n'est pas correct. Veuillez vérifier que vous avez entré correctement votre numéro de téléphone.
+          invalid_from_number: Le numéro de l'expéditeur n'est pas correctement configuré
+            ou n'est pas capable d'envoyer des messages. Veuillez contacter le support
+            de la plateforme pour obtenir de l'aide supplémentaire.
+          invalid_geo_permission: Le système n'est pas configuré pour envoyer des
+            messages dans votre pays. Veuillez contacter le support de la plateforme
+            pour obtenir de l'aide supplémentaire.
+          invalid_to_number: Le numéro de téléphone que vous avez fourni n'est pas
+            correct. Veuillez vérifier que vous avez entré correctement votre numéro
+            de téléphone.
           success: Code de vérification envoyé à %{phone}.
-          text_message: Utilisez le code %{verification} pour vous connecter à la plateforme.
-          unknown: Une erreur s'est produite et a été journalisée, veuillez réessayer. Si l'erreur persiste, veuillez contacter le support de la plateforme pour obtenir de l'aide supplémentaire.
+          text_message: Utilisez le code %{verification} pour vous connecter à la
+            plateforme.
+          unknown: Une erreur s'est produite et a été journalisée, veuillez réessayer.
+            Si l'erreur persiste, veuillez contacter le support de la plateforme pour
+            obtenir de l'aide supplémentaire.
         verify:
           have_not_received: Vous n'avez pas reçu le code ?
           incorrect_email: "(adresse incorrecte ?)"
@@ -116,6 +149,6 @@ fr:
         welcome: Bienvenue sur la <br><strong>plateforme %{organization} !</strong>
     shared:
       half_signup_login_modal:
-        sign_up: S'inscrire
         close_modal: Fermer
         please_sign_in: Veuillez vous connecter
+        sign_up: S'inscrire

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -60,7 +60,7 @@ fr:
       quick_auth:
         another_method: Utiliser une autre méthode
         authenticate:
-          unnamed_user: Utilisateur anonyme
+          unnamed_user: anonym
         authenticate_user:
           authenticity_token: Votre session a expiré, veuillez à nouveau remplir le
             formulaire.

--- a/lib/decidim/half_signup.rb
+++ b/lib/decidim/half_signup.rb
@@ -37,5 +37,10 @@ module Decidim
     config_accessor :auth_code_length do
       4
     end
+
+    # Default configuration to enable or disable the CSRF token verification
+    config_accessor :skip_csrf do
+      false
+    end
   end
 end


### PR DESCRIPTION
#### Description 

- [x] Use transaction in authenticate command
- [x] Modify french nickname to "utilisateur_anonyme_...." to "anonym_...."
- [x] Rescue 422 Authenticity token with redirect_back method
- [x] Allow to disable CSRF verification (enabled by default)
- [x] Add config accessor `Decidim::HalfSignup.skip_csrf`