### PR TITLE
Fix double phone vote

### DIFF
--- a/app/commands/decidim/half_signup/authenticate_user.rb
+++ b/app/commands/decidim/half_signup/authenticate_user.rb
@@ -102,7 +102,7 @@ module Decidim
       end
 
       def check_phone_difference(user)
-        user.phone_number.present? && (user.phone_number != data["phone"].to_s || user.phone_country != data["country"])
+        user.phone_number.present? && (user.phone_number == data["phone"].to_s && user.phone_country == data["country"])
       end
 
       def find_user_by_phone_country(data)

--- a/app/commands/decidim/half_signup/send_verification.rb
+++ b/app/commands/decidim/half_signup/send_verification.rb
@@ -13,7 +13,7 @@ module Decidim
         return broadcast(:invalid) unless @form.valid?
 
         if @form.auth_method == "sms"
-          return broadcast(:invalid, "non disponible") if registered_user_with_same_phone_and_country?
+          return broadcast(:invalid, :already_exists) if registered_user_with_same_phone_and_country?
 
           result = send_sms_verification!
           return broadcast(:invalid, @sms_gateway_error_code) unless result

--- a/app/commands/decidim/half_signup/send_verification.rb
+++ b/app/commands/decidim/half_signup/send_verification.rb
@@ -13,6 +13,8 @@ module Decidim
         return broadcast(:invalid) unless @form.valid?
 
         if @form.auth_method == "sms"
+          return broadcast(:invalid, "non disponible") if registered_user_with_same_phone_and_country?
+
           result = send_sms_verification!
           return broadcast(:invalid, @sms_gateway_error_code) unless result
         else
@@ -82,6 +84,13 @@ module Decidim
                             ).deliver_later
 
         verification_code
+      end
+
+      def registered_user_with_same_phone_and_country?
+        current_user = Decidim::User.find(session[:user_id]) if session[:user_id]
+        current_user && !current_user.phone_number && Decidim::User.where(phone_number: @form.phone_number, phone_country: @form.phone_country).where.not(
+          "decidim_users.email ILIKE ?", "%quick_auth%"
+        ).present?
       end
     end
   end

--- a/app/commands/decidim/half_signup/send_verification.rb
+++ b/app/commands/decidim/half_signup/send_verification.rb
@@ -46,7 +46,7 @@ module Decidim
 
             Decidim.config.sms_gateway_service.constantize.new(
               phone_number,
-              I18n.t("text_message", scope: "decidim.half_signup.quick_auth.sms_verification", verification: verification_code),
+              verification_code,
               **gateway_context
             )
           end

--- a/app/commands/decidim/half_signup/send_verification.rb
+++ b/app/commands/decidim/half_signup/send_verification.rb
@@ -88,9 +88,7 @@ module Decidim
 
       def registered_user_with_same_phone_and_country?
         current_user = Decidim::User.find(session[:user_id]) if session[:user_id]
-        current_user && !current_user.phone_number && Decidim::User.where(phone_number: @form.phone_number, phone_country: @form.phone_country).where.not(
-          "decidim_users.email ILIKE ?", "%quick_auth%"
-        ).present?
+        current_user && !current_user.phone_number && Decidim::User.where(phone_number: @form.phone_number, phone_country: @form.phone_country).not_anonymous.present?
       end
     end
   end

--- a/app/controllers/decidim/half_signup/quick_auth_controller.rb
+++ b/app/controllers/decidim/half_signup/quick_auth_controller.rb
@@ -38,7 +38,9 @@ module Decidim
           end
 
           on(:invalid) do |error_code|
-            flash.now[:alert] = if error_code
+            flash.now[:alert] = if error_code == "non disponible"
+                                  I18n.t("already_exists", scope: "decidim.half_signup.quick_auth.sms_verification")
+                                elsif error_code
                                   sms_sending_error(error_code)
                                 else
                                   I18n.t("unknown", scope: "decidim.half_signup.quick_auth.sms_verification")

--- a/app/controllers/decidim/half_signup/quick_auth_controller.rb
+++ b/app/controllers/decidim/half_signup/quick_auth_controller.rb
@@ -38,7 +38,7 @@ module Decidim
           end
 
           on(:invalid) do |error_code|
-            flash.now[:alert] = if error_code == "non disponible"
+            flash.now[:alert] = if error_code == :already_exists
                                   I18n.t("already_exists", scope: "decidim.half_signup.quick_auth.sms_verification")
                                 elsif error_code
                                   sms_sending_error(error_code)

--- a/app/models/decidim/user.rb
+++ b/app/models/decidim/user.rb
@@ -1,0 +1,333 @@
+# frozen_string_literal: true
+
+require "devise/models/decidim_validatable"
+require "devise/models/decidim_newsletterable"
+require "valid_email2"
+
+module Decidim
+  # A User is a participant that wants to join the platform to engage.
+  class User < UserBaseEntity
+    include Decidim::DownloadYourData
+    include Decidim::Searchable
+    include Decidim::ActsAsAuthor
+    include Decidim::UserReportable
+    include Decidim::Traceable
+
+    REGEXP_NICKNAME = /\A[\w\-]+\z/
+
+    class Roles
+      def self.all
+        Decidim.config.user_roles
+      end
+    end
+
+    devise :invitable, :database_authenticatable, :registerable, :confirmable, :timeoutable,
+           :recoverable, :trackable, :lockable,
+           :decidim_validatable, :decidim_newsletterable,
+           :omniauthable, omniauth_providers: Decidim::OmniauthProvider.available.keys,
+           request_keys: [:env], reset_password_keys: [:decidim_organization_id, :email],
+           confirmation_keys: [:decidim_organization_id, :email]
+    devise :rememberable if Decidim.enable_remember_me
+
+    has_many :identities, foreign_key: "decidim_user_id", class_name: "Decidim::Identity", dependent: :destroy
+    has_many :memberships, class_name: "Decidim::UserGroupMembership", foreign_key: :decidim_user_id, dependent: :destroy
+    has_many :user_groups, through: :memberships, class_name: "Decidim::UserGroup", foreign_key: :decidim_user_group_id
+    has_many :access_grants, class_name: "Doorkeeper::AccessGrant", foreign_key: :resource_owner_id, dependent: :destroy
+    has_many :access_tokens, class_name: "Doorkeeper::AccessToken", foreign_key: :resource_owner_id, dependent: :destroy
+    has_many :reminders, foreign_key: "decidim_user_id", class_name: "Decidim::Reminder", dependent: :destroy
+
+    validates :name, presence: true, unless: -> { deleted? }
+    validates :nickname,
+              presence: true,
+              format: { with: REGEXP_NICKNAME },
+              length: { maximum: Decidim::User.nickname_max_length },
+              unless: -> { deleted? || managed? }
+    validates :locale, inclusion: { in: :available_locales }, allow_blank: true
+    validates :tos_agreement, acceptance: true, allow_nil: false, on: :create
+    validates :tos_agreement, acceptance: true, if: :user_invited?
+    validates :email, :nickname, uniqueness: { scope: :organization }, unless: -> { deleted? || managed? || nickname.blank? }
+    validates :phone_number, uniqueness: { scope: :phone_country }
+
+    validate :all_roles_are_valid
+
+    has_one_attached :download_your_data_file
+
+    scope :not_deleted, -> { where(deleted_at: nil) }
+
+    scope :managed, -> { where(managed: true) }
+    scope :not_managed, -> { where(managed: false) }
+
+    scope :officialized, -> { where.not(officialized_at: nil) }
+    scope :not_officialized, -> { where(officialized_at: nil) }
+
+    scope :interested_in_scopes, lambda { |scope_ids|
+      actual_ids = scope_ids.select(&:presence)
+      if actual_ids.count.positive?
+        ids = actual_ids.map(&:to_i).join(",")
+        where(Arel.sql("extended_data->'interested_scopes' @> ANY('{#{ids}}')").to_s)
+      else
+        # Do not apply the scope filter when there are scope ids available. Note
+        # that the active record scope must always return an active record
+        # collection.
+        self
+      end
+    }
+
+    scope :org_admins_except_me, ->(user) { where(organization: user.organization, admin: true).where.not(id: user.id) }
+
+    attr_accessor :newsletter_notifications
+
+    searchable_fields({
+                        # scope_id: :decidim_scope_id,
+                        organization_id: :decidim_organization_id,
+                        A: :name,
+                        B: :nickname,
+                        datetime: :created_at
+                      },
+                      index_on_create: ->(user) { !(user.deleted? || user.blocked?) },
+                      index_on_update: ->(user) { !(user.deleted? || user.blocked?) })
+
+    before_save :ensure_encrypted_password
+    before_save :save_password_change
+
+    def user_invited?
+      invitation_token_changed? && invitation_accepted_at_changed?
+    end
+
+    # Public: Allows customizing the invitation instruction email content when
+    # inviting a user.
+    #
+    # Returns a String.
+    attr_accessor :invitation_instructions
+
+    def invitation_pending?
+      invited_to_sign_up? && !invitation_accepted?
+    end
+
+    # Returns the user corresponding to the given +email+ if it exists and has pending invitations,
+    #   otherwise returns nil.
+    def self.has_pending_invitations?(organization_id, email)
+      invitation_not_accepted.find_by(decidim_organization_id: organization_id, email: email)
+    end
+
+    # Returns the presenter for this author, to be used in the views.
+    # Required by ActsAsAuthor.
+    def presenter
+      Decidim::UserPresenter.new(self)
+    end
+
+    def self.log_presenter_class_for(_log)
+      Decidim::AdminLog::UserPresenter
+    end
+
+    # Checks if the user has the given `role` or not.
+    #
+    # role - a String or a Symbol that represents the role that is being
+    #   checked
+    #
+    # Returns a boolean.
+    def role?(role)
+      roles.include?(role.to_s)
+    end
+
+    # Public: Returns the active role of the user
+    def active_role
+      admin ? "admin" : roles.first
+    end
+
+    # Public: returns the user's name or the default one
+    def name
+      super || I18n.t("decidim.anonymous_user")
+    end
+
+    # Check if the user account has been deleted or not
+    def deleted?
+      deleted_at.present?
+    end
+
+    # Public: whether the user has been officialized or not
+    def officialized?
+      !officialized_at.nil?
+    end
+
+    def follows?(followable)
+      Decidim::Follow.where(user: self, followable: followable).any?
+    end
+
+    # Public: whether the user accepts direct messages from another
+    def accepts_conversation?(user)
+      return follows?(user) if direct_message_types == "followed-only"
+
+      true
+    end
+
+    def unread_conversations
+      Decidim::Messaging::Conversation.unread_by(self)
+    end
+
+    def unread_messages_count
+      @unread_messages_count ||= Decidim::Messaging::Receipt.unread_count(self)
+    end
+
+    # Check if the user exists with the given email and the current organization
+    #
+    # warden_conditions - A hash with the authentication conditions
+    #                   * email - a String that represents user's email.
+    #                   * env - A Hash containing environment variables.
+    # Returns a User.
+    def self.find_for_authentication(warden_conditions)
+      organization = warden_conditions.dig(:env, "decidim.current_organization")
+      find_by(
+        email: warden_conditions[:email].to_s.downcase,
+        decidim_organization_id: organization.id
+      )
+    end
+
+    def self.user_collection(user)
+      where(id: user.id)
+    end
+
+    def self.export_serializer
+      Decidim::DownloadYourDataSerializers::DownloadYourDataUserSerializer
+    end
+
+    def self.download_your_data_images(user)
+      user_collection(user).map(&:avatar)
+    end
+
+    def tos_accepted?
+      return true if managed
+      return false if accepted_tos_version.nil?
+
+      # For some reason, if we don't use `#to_i` here we get some
+      # cases where the comparison returns false, but calling `#to_i` returns
+      # the same number :/
+      accepted_tos_version.to_i >= organization.tos_version.to_i
+    end
+
+    def admin_terms_accepted?
+      return true if admin_terms_accepted_at
+    end
+
+    # Whether this user can be verified against some authorization or not.
+    def verifiable?
+      confirmed? || managed? || being_impersonated?
+    end
+
+    def being_impersonated?
+      ImpersonationLog.active.exists?(user: self)
+    end
+
+    def interested_scopes_ids
+      extended_data["interested_scopes"] || []
+    end
+
+    def interested_scopes
+      @interested_scopes ||= organization.scopes.where(id: interested_scopes_ids)
+    end
+
+    def user_name
+      extended_data["user_name"] || name
+    end
+
+    # return the groups where this user has been accepted
+    def accepted_user_groups
+      UserGroups::AcceptedUserGroups.for(self)
+    end
+
+    # return the groups where this user has admin permissions
+    def manageable_user_groups
+      UserGroups::ManageableUserGroups.for(self)
+    end
+
+    def authenticatable_salt
+      "#{super}#{session_token}"
+    end
+
+    def invalidate_all_sessions!
+      self.session_token = SecureRandom.hex
+      save!
+    end
+
+    ransacker :invitation_accepted_at do
+      Arel.sql(%{("decidim_users"."invitation_accepted_at")::text})
+    end
+
+    ransacker :last_sign_in_at do
+      Arel.sql(%{("decidim_users"."last_sign_in_at")::text})
+    end
+
+    def notifications_subscriptions
+      notification_settings.fetch("subscriptions", {})
+    end
+
+    def needs_password_update?
+      return false unless admin?
+      return false unless Decidim.config.admin_password_strong
+      return true if password_updated_at.blank?
+
+      password_updated_at < Decidim.config.admin_password_expiration_days.days.ago
+    end
+
+    protected
+
+    # Overrides devise email required validation.
+    # If the user has been deleted or it is managed the email field is not required anymore.
+    def email_required?
+      return false if deleted? || managed?
+
+      super
+    end
+
+    # Overrides devise password required validation.
+    # If the user is managed the password field is not required anymore.
+    def password_required?
+      return false if managed?
+
+      super
+    end
+
+    def after_confirmation
+      return unless organization.send_welcome_notification?
+
+      Decidim::EventsManager.publish(
+        event: "decidim.events.core.welcome_notification",
+        event_class: WelcomeNotificationEvent,
+        resource: self,
+        affected_users: [self]
+      )
+    end
+
+    private
+
+    # Changes default Devise behaviour to use ActiveJob to send async emails.
+    def send_devise_notification(notification, *args)
+      devise_mailer.send(notification, self, *args).deliver_later
+    end
+
+    def all_roles_are_valid
+      errors.add(:roles, :invalid) unless roles.compact.all? { |role| Roles.all.include?(role) }
+    end
+
+    def available_locales
+      Decidim.available_locales.map(&:to_s)
+    end
+
+    def ensure_encrypted_password
+      restore_encrypted_password! if will_save_change_to_encrypted_password? && encrypted_password.blank?
+    end
+
+    def save_password_change
+      return unless persisted?
+      return unless encrypted_password_changed?
+      return unless admin?
+      return unless Decidim.config.admin_password_strong
+
+      # We don't want to run validations here because that could lead to an endless validation loop.
+      # rubocop:disable Rails/SkipsModelValidations
+      update_column(:password_updated_at, Time.current)
+      update_column(:previous_passwords, [encrypted_password_was, *previous_passwords].first(Decidim.config.admin_password_repetition_times))
+      # rubocop:enable Rails/SkipsModelValidations
+    end
+  end
+end

--- a/app/models/decidim/user.rb
+++ b/app/models/decidim/user.rb
@@ -46,7 +46,7 @@ module Decidim
     validates :tos_agreement, acceptance: true, allow_nil: false, on: :create
     validates :tos_agreement, acceptance: true, if: :user_invited?
     validates :email, :nickname, uniqueness: { scope: :organization }, unless: -> { deleted? || managed? || nickname.blank? }
-    validates :phone_number, uniqueness: { scope: :phone_country }
+    validates :phone_number, uniqueness: { scope: :phone_country }, unless: -> { new_record? }
 
     validate :all_roles_are_valid
 

--- a/app/models/decidim/user.rb
+++ b/app/models/decidim/user.rb
@@ -25,8 +25,8 @@ module Decidim
            :recoverable, :trackable, :lockable,
            :decidim_validatable, :decidim_newsletterable,
            :omniauthable, omniauth_providers: Decidim::OmniauthProvider.available.keys,
-           request_keys: [:env], reset_password_keys: [:decidim_organization_id, :email],
-           confirmation_keys: [:decidim_organization_id, :email]
+                          request_keys: [:env], reset_password_keys: [:decidim_organization_id, :email],
+                          confirmation_keys: [:decidim_organization_id, :email]
     devise :rememberable if Decidim.enable_remember_me
 
     has_many :identities, foreign_key: "decidim_user_id", class_name: "Decidim::Identity", dependent: :destroy
@@ -52,6 +52,7 @@ module Decidim
 
     has_one_attached :download_your_data_file
 
+    scope :not_anonymous, -> { where.not("decidim_users.email ILIKE ?", "%quick_auth%") }
     scope :not_deleted, -> { where(deleted_at: nil) }
 
     scope :managed, -> { where(managed: true) }

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -8,3 +8,4 @@ ignore_unused:
 
 ignore_missing:
   - decidim.participatory_processes.scopes.global
+  - Decidim::Verifications::Sms::ExampleGateway

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -123,6 +123,7 @@ en:
           text_message: Use code %{verification} to sign in to the platform.
           unknown: An error occured which has been logged, please try again. If the
             error persists, please contact the platform support for further help.
+          already_exists: This phone number is not available, please enter another number.
         verify:
           have_not_received: Haven't received the code?
           incorrect_email: "(incorrect address?)"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -104,6 +104,7 @@ fr:
           success: Code de vérification envoyé à %{phone}.
           text_message: Utilisez le code %{verification} pour vous connecter à la plateforme.
           unknown: Une erreur s'est produite et a été journalisée, veuillez réessayer. Si l'erreur persiste, veuillez contacter le support de la plateforme pour obtenir de l'aide supplémentaire.
+          already_exists: Ce numéro de téléphone n'est pas disponible, veuillez renseigner un autre numéro.
         verify:
           have_not_received: Vous n'avez pas reçu le code ?
           incorrect_email: "(adresse incorrecte ?)"

--- a/spec/commands/decidim/half_signup/send_verification_spec.rb
+++ b/spec/commands/decidim/half_signup/send_verification_spec.rb
@@ -35,7 +35,7 @@ describe Decidim::HalfSignup::SendVerification, type: :command do
         allow(form).to receive(:valid?).and_return(false)
       end
 
-      it "broadcasts :invlid" do
+      it "broadcasts :invalid" do
         expect(subject).to broadcast(:invalid)
         expect(Decidim::HalfSignup::VerificationCodeMailer).not_to receive(:call)
       end
@@ -111,11 +111,11 @@ describe Decidim::HalfSignup::SendVerification, type: :command do
       context "when another gateway configured" do
         let(:foo_gateway) do
           Class.new do
-            attr_reader :number, :message, :context
+            attr_reader :number, :code, :context
 
-            def initialize(number, message, context = {})
+            def initialize(number, code, context = {})
               @number = number
-              @message = message
+              @code = code
               @context = context
             end
 
@@ -137,7 +137,7 @@ describe Decidim::HalfSignup::SendVerification, type: :command do
 
         it "sets the correct values" do
           expect(gateway.number).to eq("+358#{phone_number}")
-          expect(gateway.message).to eq("Use code #{verification} to sign in to the platform.")
+          expect(gateway.code).to eq(verification)
           expect(gateway.context).to eq({})
         end
 

--- a/spec/commands/decidim/half_signup/send_verification_spec.rb
+++ b/spec/commands/decidim/half_signup/send_verification_spec.rb
@@ -99,7 +99,7 @@ describe Decidim::HalfSignup::SendVerification, type: :command do
         it "does not deliver the verification code" do
           Decidim::User.create!(email: generate(:email), name: generate(:name), nickname: generate(:nickname), organization: organization,
                                 tos_agreement: "1", phone_number:  "9876543", phone_country: "FR", password: "DecidiM123456789")
-          expect(subject).to broadcast(:invalid, "non disponible")
+          expect(subject).to broadcast(:invalid, :already_exists)
           expect(Decidim::HalfSignup::VerificationCodeMailer).not_to receive(:call)
         end
       end

--- a/spec/commands/decidim/half_signup/send_verification_spec.rb
+++ b/spec/commands/decidim/half_signup/send_verification_spec.rb
@@ -6,12 +6,14 @@ describe Decidim::HalfSignup::SendVerification, type: :command do
   subject { command.call }
 
   let!(:organization) { create(:organization) }
+  let!(:user) { create(:user, :confirmed, organization: organization) }
+  let!(:session) { { user_id: user.id } }
   let(:command) { described_class.new(form) }
   let(:verification) { "1234" }
   let(:email) { nil }
+  let(:valid) { true }
   let(:phone_number) { nil }
   let(:phone_country) { nil }
-  let(:valid) { true }
   let(:form) do
     double(
       valid?: valid,
@@ -75,10 +77,37 @@ describe Decidim::HalfSignup::SendVerification, type: :command do
     end
 
     context "when form is valid" do
-      let!(:phone_number) { 4_577_886_622 }
-      let!(:phone_country) { "FI" }
+      before do
+        allow_any_instance_of(Decidim::HalfSignup::SendVerification).to receive(:session).and_return(session)
+      end
+
+      context "and an anonymous user already exists with same phone and country" do
+        let(:phone_number) { 1_123_324_356 }
+        let(:phone_country) { "FR" }
+
+        it "delivers the verification code" do
+          Decidim::User.create!(email: "quick_auth@example.org", name: generate(:name), nickname: generate(:nickname), organization: organization,
+                                tos_agreement: "1", phone_number:  "1_123_324_356", phone_country: "FR", password: "DecidiM123456789")
+          expect(subject).to broadcast(:ok, verification)
+        end
+      end
+
+      context "and a registered user already exists with same phone and country" do
+        let(:phone_number) { 9_876_543 }
+        let(:phone_country) { "FR" }
+
+        it "does not deliver the verification code" do
+          Decidim::User.create!(email: generate(:email), name: generate(:name), nickname: generate(:nickname), organization: organization,
+                                tos_agreement: "1", phone_number:  "9876543", phone_country: "FR", password: "DecidiM123456789")
+          expect(subject).to broadcast(:invalid, "non disponible")
+          expect(Decidim::HalfSignup::VerificationCodeMailer).not_to receive(:call)
+        end
+      end
 
       context "when default gateway" do
+        let(:phone_number) { 4_577_886_622 }
+        let(:phone_country) { "FI" }
+
         context "when delivers the code" do
           it "delivers the verification code" do
             allow(gateway).to receive(:deliver_code).and_return(true)
@@ -108,7 +137,9 @@ describe Decidim::HalfSignup::SendVerification, type: :command do
         end
       end
 
-      context "when another gateway configured" do
+      context "and another gateway is configured" do
+        let(:phone_number) { 4_577_886_622 }
+        let(:phone_country) { "FI" }
         let(:foo_gateway) do
           Class.new do
             attr_reader :number, :code, :context

--- a/spec/models/decidim/user_spec.rb
+++ b/spec/models/decidim/user_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 module Decidim

--- a/spec/models/decidim/user_spec.rb
+++ b/spec/models/decidim/user_spec.rb
@@ -1,0 +1,45 @@
+require "spec_helper"
+
+module Decidim
+  describe User do
+    subject { user }
+
+    let(:organization) { create(:organization) }
+    let(:user) { build(:user, organization: organization) }
+    let!(:existing_user) { create(:user, organization: organization, phone_number: "123-456-7890", phone_country: "FR") }
+
+    describe "uniqueness validation on phone_number/phone_country uniqueness" do
+      context "when new user is built without phone_number/phone_country" do
+        it "is valid" do
+          expect(user).to be_valid
+        end
+      end
+
+      context "when new user is updated with existing phone_number/phone_country" do
+        let(:new_user) { create(:user, organization: organization) }
+
+        it "does not udpate user" do
+          expect { new_user.update!(phone_number: "123-456-7890", phone_country: "FR") }.to raise_error(ActiveRecord::RecordInvalid)
+        end
+      end
+    end
+
+    describe "not_anonymous scope" do
+      context "when user is anonymous" do
+        let(:new_user) { create(:user, organization: organization, email: "quick_auth@example.org") }
+
+        it "is not included in the scope" do
+          expect(Decidim::User.not_anonymous).not_to include(new_user)
+        end
+      end
+
+      context "when user is not anonymous" do
+        let(:new_user) { create(:user, organization: organization) }
+
+        it "is included in the scope" do
+          expect(Decidim::User.not_anonymous).to include(new_user)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Problem:
If i create an account with no phone number, I can the vote and enter a phone number that already belongs to another account, and vote twice with the same phone number

Related Issues: 
Notion card => https://www.notion.so/opensourcepolitics/bd4bf860eab94f9daca7da803f09e3b2?v=c96df65755dd403d95e86f82d7749709&p=39467ef809e94526bf88fee4516f89f3&pm=c

Testing:

1. As a user, create an account with email
2. As  user, go to Assemblies > choose one assembly > go to budgets > choose one budget > vote by providing a phone number
3. As a second user, create an account with email
4. As  a second user, go to Assemblies > choose one assembly > go to budgets > choose one budget > vote by providing the same phone number/phone country provided by first user
5. Notice that you have a message that indicates phone number is not available and you must provide another number

If you have time, you can also check that those paths still work well:

1. As a user not signed in, vote with only your phone number (anonymous user)
2. As a user not signed in, vote with only your phone number by providing the same phone number already linked to an account and note that you are signed in and not anonymous user anymore

Tasks:
Add specs