### PR TITLE
feat: Disable SMS Auth Activation if SMS Gateway is not provided

### DIFF
--- a/app/commands/decidim/half_signup/admin/update_auth_settings.rb
+++ b/app/commands/decidim/half_signup/admin/update_auth_settings.rb
@@ -17,7 +17,7 @@ module Decidim
 
         def call
           return broadcast(:invalid) if form.invalid?
-          return broadcast(:sms_service_not_configured) if form.enable_partial_sms_signup && !check_sms_service
+          return broadcast(:sms_service_not_configured) if form.enable_partial_sms_signup && !sms_gateway_service_configured?
 
           update_auth_settings
           broadcast(:ok)
@@ -27,7 +27,7 @@ module Decidim
 
         attr_reader :form
 
-        def check_sms_service
+        def sms_gateway_service_configured?
           Decidim.config.sms_gateway_service.present?
         end
 

--- a/app/commands/decidim/half_signup/admin/update_auth_settings.rb
+++ b/app/commands/decidim/half_signup/admin/update_auth_settings.rb
@@ -17,6 +17,7 @@ module Decidim
 
         def call
           return broadcast(:invalid) if form.invalid?
+          return broadcast(:sms_service_not_configured) if form.enable_partial_sms_signup && !check_sms_service
 
           update_auth_settings
           broadcast(:ok)
@@ -25,6 +26,10 @@ module Decidim
         private
 
         attr_reader :form
+
+        def check_sms_service
+          Decidim.config.sms_gateway_service.present?
+        end
 
         def update_auth_settings
           Decidim.traceability.update!(

--- a/app/controllers/decidim/half_signup/admin/auth_settings_controller.rb
+++ b/app/controllers/decidim/half_signup/admin/auth_settings_controller.rb
@@ -28,6 +28,11 @@ module Decidim
               flash.now[:alert] = I18n.t("organization.update.error", scope: "decidim.admin")
               render :edit
             end
+
+            on(:sms_service_not_configured) do
+              flash[:alert] = I18n.t("sms_gateway_service_not_defined", scope: "decidim.half_signup.admin.auth_settings")
+              redirect_to action: :edit
+            end
           end
         end
       end

--- a/app/views/decidim/half_signup/admin/auth_settings/_form.html.erb
+++ b/app/views/decidim/half_signup/admin/auth_settings/_form.html.erb
@@ -1,7 +1,16 @@
 <div class="wrapper">
   <div class="row">
     <div class="field">
-      <%= form.check_box :enable_partial_sms_signup, help_text: t("help_text", scope:"decidim.half_signup.admin.auth_settings.sms") %>
+      <% if Decidim.config.sms_gateway_service.nil? %>
+        <div class="help-text">
+          <%= form.check_box :enable_partial_sms_signup, disabled: true  %>
+        </div>
+        <div class="text-alert help-text">
+          <%= t("help_text", scope:"decidim.half_signup.admin.auth_settings.sms_disabled") %>
+        </div>
+      <% else %>
+        <%= form.check_box :enable_partial_sms_signup, help_text: t("help_text", scope:"decidim.half_signup.admin.auth_settings.sms") %>
+      <% end %>
     </div>
     <br/>
     <div class="field">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -49,6 +49,10 @@ en:
           sms:
             help_text: This option allows users to sign up and sign in to the platform
               using their email address by receiving a verification code by SMS.
+          sms_disabled:
+            help_text: This option is disabled please contact the host of the platform
+              to enable it.
+          sms_gateway_service_not_defined: The SMS gateway service is not defined.
           title: Settings available through code
       menu:
         auth_settings: Authentication settings

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -54,6 +54,11 @@ fr:
             help_text: Cette option permet aux utilisateurs de s'inscrire et de se
               connecter à la plateforme en utilisant leur adresse e-mail en recevant
               un code de vérification par SMS.
+          sms_disabled:
+            help_text: Cette option est désactivée, veuillez contacter l'hôte de
+              la plateforme pour l'activer.
+          sms_gateway_service_not_defined: Le service de passerelle SMS n'est pas
+            défini.
           title: Paramètres disponibles via le code
       menu:
         auth_settings: Paramètres d'authentification

--- a/spec/commands/decidim/half_signup/admin/update_auth_settings_spec.rb
+++ b/spec/commands/decidim/half_signup/admin/update_auth_settings_spec.rb
@@ -16,12 +16,14 @@ RSpec.describe Decidim::HalfSignup::Admin::UpdateAuthSettings do
     )
   end
   let(:command) { described_class.new(auth_settings, form) }
-  let(:sms_gateway_service) { "Decidim::Verifications::Sms::ExampleGateway" }
+  let(:sms_gateway_service) { instance_double(Decidim::Verifications::Sms::ExampleGateway, present?: true) }
 
   before do
-    Decidim.configure do |config|
-      config.sms_gateway_service = sms_gateway_service
-    end
+    allow(Decidim.config).to receive(:sms_gateway_service).and_return(sms_gateway_service)
+  end
+
+  after do
+    allow(Decidim.config).to receive(:sms_gateway_service).and_call_original
   end
 
   describe "#call" do

--- a/spec/commands/decidim/half_signup/admin/update_auth_settings_spec.rb
+++ b/spec/commands/decidim/half_signup/admin/update_auth_settings_spec.rb
@@ -16,6 +16,13 @@ RSpec.describe Decidim::HalfSignup::Admin::UpdateAuthSettings do
     )
   end
   let(:command) { described_class.new(auth_settings, form) }
+  let(:sms_gateway_service) { "Decidim::Verifications::Sms::ExampleGateway" }
+
+  before do
+    Decidim.configure do |config|
+      config.sms_gateway_service = sms_gateway_service
+    end
+  end
 
   describe "#call" do
     subject { command.call }
@@ -46,6 +53,14 @@ RSpec.describe Decidim::HalfSignup::Admin::UpdateAuthSettings do
 
       it "does broadcasts :invalid" do
         expect(subject).to broadcast(:invalid)
+      end
+    end
+
+    context "when the sms gateway is not defined" do
+      let(:sms_gateway_service) { nil }
+
+      it "broadcasts :sms_service_not_configured" do
+        expect(subject).to broadcast(:sms_service_not_configured)
       end
     end
   end

--- a/spec/commands/decidim/half_signup/send_verification_spec.rb
+++ b/spec/commands/decidim/half_signup/send_verification_spec.rb
@@ -34,6 +34,10 @@ describe Decidim::HalfSignup::SendVerification, type: :command do
     end
   end
 
+  after do
+    allow(Decidim.config).to receive(:sms_gateway_service).and_call_original
+  end
+
   describe "when email" do
     let!(:auth_method) { "email" }
 

--- a/spec/commands/decidim/half_signup/send_verification_spec.rb
+++ b/spec/commands/decidim/half_signup/send_verification_spec.rb
@@ -14,6 +14,7 @@ describe Decidim::HalfSignup::SendVerification, type: :command do
   let(:valid) { true }
   let(:phone_number) { nil }
   let(:phone_country) { nil }
+  let(:sms_gateway_service) { "Decidim::Verifications::Sms::ExampleGateway" }
   let(:form) do
     double(
       valid?: valid,
@@ -27,6 +28,10 @@ describe Decidim::HalfSignup::SendVerification, type: :command do
 
   before do
     allow(SecureRandom).to receive(:random_number).and_return(verification)
+
+    Decidim.configure do |config|
+      config.sms_gateway_service = sms_gateway_service
+    end
   end
 
   describe "when email" do

--- a/spec/controllers/decidim/half_signup/quick_auth_controller_spec.rb
+++ b/spec/controllers/decidim/half_signup/quick_auth_controller_spec.rb
@@ -36,9 +36,11 @@ RSpec.describe Decidim::HalfSignup::QuickAuthController, type: :controller do
     request.env["devise.mapping"] = ::Devise.mappings[:user]
     request.session[:auth_attempt] = auth_session
 
-    Decidim.configure do |config|
-      config.sms_gateway_service = sms_gateway_service
-    end
+    allow(Decidim.config).to receive(:sms_gateway_service).and_return(sms_gateway_service)
+  end
+
+  after do
+    allow(Decidim.config).to receive(:sms_gateway_service).and_call_original
   end
 
   describe "GET #sms" do

--- a/spec/controllers/decidim/half_signup/quick_auth_controller_spec.rb
+++ b/spec/controllers/decidim/half_signup/quick_auth_controller_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Decidim::HalfSignup::QuickAuthController, type: :controller do
   let(:attempts) { 0 }
   let!(:correct_code) { "correct code" }
   let!(:wrong_code) { "wrong code" }
+  let(:sms_gateway_service) { "Decidim::Verifications::Sms::ExampleGateway" }
   let(:auth_session) do
     {
       "code" => "correct code",
@@ -34,6 +35,10 @@ RSpec.describe Decidim::HalfSignup::QuickAuthController, type: :controller do
     request.env["decidim.current_organization"] = organization
     request.env["devise.mapping"] = ::Devise.mappings[:user]
     request.session[:auth_attempt] = auth_session
+
+    Decidim.configure do |config|
+      config.sms_gateway_service = sms_gateway_service
+    end
   end
 
   describe "GET #sms" do

--- a/spec/system/add_update_phone_number_spec.rb
+++ b/spec/system/add_update_phone_number_spec.rb
@@ -15,9 +15,11 @@ describe "Add/update phone number", type: :system do
     switch_to_host(organization.host)
     visit decidim.account_path
 
-    Decidim.configure do |config|
-      config.sms_gateway_service = sms_gateway_service
-    end
+    allow(Decidim.config).to receive(:sms_gateway_service).and_return(sms_gateway_service)
+  end
+
+  after do
+    allow(Decidim.config).to receive(:sms_gateway_service).and_call_original
   end
 
   context "when sms_auth is not enabled" do

--- a/spec/system/add_update_phone_number_spec.rb
+++ b/spec/system/add_update_phone_number_spec.rb
@@ -7,12 +7,17 @@ describe "Add/update phone number", type: :system do
   let(:user) { create(:user, :confirmed, organization: organization) }
   let!(:auth_settings) { create(:auth_setting, organization: organization) }
   let(:decidim_half_signup_admin) { Decidim::HalfSignup::AdminEngine.routes.url_helpers }
+  let(:sms_gateway_service) { "Decidim::Verifications::Sms::ExampleGateway" }
   let(:phone) { "4578878784" }
 
   before do
     sign_in user
     switch_to_host(organization.host)
     visit decidim.account_path
+
+    Decidim.configure do |config|
+      config.sms_gateway_service = sms_gateway_service
+    end
   end
 
   context "when sms_auth is not enabled" do

--- a/spec/system/admin_manage_auth_settings_spec.rb
+++ b/spec/system/admin_manage_auth_settings_spec.rb
@@ -8,11 +8,16 @@ describe "Admin manage auth settings", type: :system do
   let(:admin) { create(:user, :admin, :confirmed, organization: organization) }
   let(:auth_settings) { create(:auth_setting, organization: organization) }
   let(:decidim_half_signup_admin) { Decidim::HalfSignup::AdminEngine.routes.url_helpers }
+  let(:sms_gateway_service) { "Decidim::Verifications::Sms::ExampleGateway" }
 
   before do
     sign_in admin
     switch_to_host(organization.host)
     visit decidim_admin.edit_organization_path
+
+    Decidim.configure do |config|
+      config.sms_gateway_service = sms_gateway_service
+    end
   end
 
   it "shows the menu in the admin panel in a correct place" do
@@ -47,5 +52,43 @@ describe "Admin manage auth settings", type: :system do
     auth_settings = Decidim::HalfSignup::AuthSetting.last
     expect(auth_settings.enable_partial_email_signup).to be(false)
     expect(auth_settings.enable_partial_sms_signup).to be(true)
+  end
+
+  it "shows a warning message when the SMS gateway service is not configured" do
+    Decidim.configure do |config|
+      config.sms_gateway_service = nil
+    end
+    click_link "Authentication settings"
+    expect(page).to have_current_path(decidim_half_signup_admin.edit_auth_setting_path(slug: "authentication_settings"))
+    expect(page).to have_css(".is-active", text: "Authentication settings")
+    expect(page.find("#auth_setting_enable_partial_sms_signup")).to be_disabled
+    expect(page).to have_content("This option is disabled please contact the host of the platform to enable it.")
+  end
+
+  it "shows an error message when the SMS gateway service is not configured if the user tries to force the change" do
+    click_link "Authentication settings"
+    expect(page).to have_current_path(decidim_half_signup_admin.edit_auth_setting_path(slug: "authentication_settings"))
+    expect(page).to have_css(".is-active", text: "Authentication settings")
+    check "Enable partial sign up and sign in using SMS verification"
+    check "Enable partial sign up and sign in using email verification"
+
+    Decidim.configure do |config|
+      config.sms_gateway_service = nil
+    end
+
+    click_button "Update"
+    expect(page).to have_current_path(decidim_half_signup_admin.edit_auth_setting_path(slug: "authentication_settings"))
+    within ".callout-wrapper" do
+      expect(page).not_to have_content("Organization updated successfully.")
+      expect(page).to have_content("The SMS gateway service is not defined.")
+    end
+    expect(page).to have_content("Settings available through code")
+    within "code" do
+      expect(page).to have_content("Decidim::HalfSignup.configure do |config|")
+    end
+    expect(page.find("#auth_setting_enable_partial_sms_signup")).not_to be_checked
+    auth_settings = Decidim::HalfSignup::AuthSetting.last
+    expect(auth_settings.enable_partial_email_signup).to be(false)
+    expect(auth_settings.enable_partial_sms_signup).to be(false)
   end
 end

--- a/spec/system/admin_manage_auth_settings_spec.rb
+++ b/spec/system/admin_manage_auth_settings_spec.rb
@@ -15,9 +15,11 @@ describe "Admin manage auth settings", type: :system do
     switch_to_host(organization.host)
     visit decidim_admin.edit_organization_path
 
-    Decidim.configure do |config|
-      config.sms_gateway_service = sms_gateway_service
-    end
+    allow(Decidim.config).to receive(:sms_gateway_service).and_return(sms_gateway_service)
+  end
+
+  after do
+    allow(Decidim.config).to receive(:sms_gateway_service).and_call_original
   end
 
   it "shows the menu in the admin panel in a correct place" do
@@ -54,41 +56,50 @@ describe "Admin manage auth settings", type: :system do
     expect(auth_settings.enable_partial_sms_signup).to be(true)
   end
 
-  it "shows a warning message when the SMS gateway service is not configured" do
-    Decidim.configure do |config|
-      config.sms_gateway_service = nil
+  context "when sms gateway service is not present" do
+    before do
+      allow(Decidim.config).to receive(:sms_gateway_service).and_return(nil)
     end
-    click_link "Authentication settings"
-    expect(page).to have_current_path(decidim_half_signup_admin.edit_auth_setting_path(slug: "authentication_settings"))
-    expect(page).to have_css(".is-active", text: "Authentication settings")
-    expect(page.find("#auth_setting_enable_partial_sms_signup")).to be_disabled
-    expect(page).to have_content("This option is disabled please contact the host of the platform to enable it.")
+
+    it "shows a warning message when the SMS gateway service is not configured" do
+      click_link "Authentication settings"
+      expect(page).to have_current_path(decidim_half_signup_admin.edit_auth_setting_path(slug: "authentication_settings"))
+      expect(page).to have_css(".is-active", text: "Authentication settings")
+      expect(page.find("#auth_setting_enable_partial_sms_signup")).to be_disabled
+      expect(page).to have_content("This option is disabled please contact the host of the platform to enable it.")
+    end
   end
 
-  it "shows an error message when the SMS gateway service is not configured if the user tries to force the change" do
-    click_link "Authentication settings"
-    expect(page).to have_current_path(decidim_half_signup_admin.edit_auth_setting_path(slug: "authentication_settings"))
-    expect(page).to have_css(".is-active", text: "Authentication settings")
-    check "Enable partial sign up and sign in using SMS verification"
-    check "Enable partial sign up and sign in using email verification"
-
-    Decidim.configure do |config|
-      config.sms_gateway_service = nil
+  context "when user tries to force the SMS verification without configuring the SMS gateway" do
+    before do
+      # Simplest way to simulate the behavior if the user tries to manually change the checkbox value even if sms_gateway_service is disabled)
+      allow(Decidim.config).to receive(:sms_gateway_service).and_return(sms_gateway_service)
     end
 
-    click_button "Update"
-    expect(page).to have_current_path(decidim_half_signup_admin.edit_auth_setting_path(slug: "authentication_settings"))
-    within ".callout-wrapper" do
-      expect(page).not_to have_content("Organization updated successfully.")
-      expect(page).to have_content("The SMS gateway service is not defined.")
+    it "shows an error message when the SMS gateway service is not configured if the user tries to force the change" do
+      click_link "Authentication settings"
+
+      expect(page).to have_current_path(decidim_half_signup_admin.edit_auth_setting_path(slug: "authentication_settings"))
+      expect(page).to have_css(".is-active", text: "Authentication settings")
+      check "Enable partial sign up and sign in using SMS verification"
+      check "Enable partial sign up and sign in using email verification"
+
+      allow(Decidim.config).to receive(:sms_gateway_service).and_return(nil)
+
+      click_button "Update"
+      expect(page).to have_current_path(decidim_half_signup_admin.edit_auth_setting_path(slug: "authentication_settings"))
+      within ".callout-wrapper" do
+        expect(page).not_to have_content("Organization updated successfully.")
+        expect(page).to have_content("The SMS gateway service is not defined.")
+      end
+      expect(page).to have_content("Settings available through code")
+      within "code" do
+        expect(page).to have_content("Decidim::HalfSignup.configure do |config|")
+      end
+      expect(page.find("#auth_setting_enable_partial_sms_signup")).not_to be_checked
+      auth_settings = Decidim::HalfSignup::AuthSetting.last
+      expect(auth_settings.enable_partial_email_signup).to be(false)
+      expect(auth_settings.enable_partial_sms_signup).to be(false)
     end
-    expect(page).to have_content("Settings available through code")
-    within "code" do
-      expect(page).to have_content("Decidim::HalfSignup.configure do |config|")
-    end
-    expect(page.find("#auth_setting_enable_partial_sms_signup")).not_to be_checked
-    auth_settings = Decidim::HalfSignup::AuthSetting.last
-    expect(auth_settings.enable_partial_email_signup).to be(false)
-    expect(auth_settings.enable_partial_sms_signup).to be(false)
   end
 end

--- a/spec/system/budgets_view_spec.rb
+++ b/spec/system/budgets_view_spec.rb
@@ -12,9 +12,11 @@ describe "Budgets view", type: :system do
   before do
     switch_to_host(organization.host)
 
-    Decidim.configure do |config|
-      config.sms_gateway_service = sms_gateway_service
-    end
+    allow(Decidim.config).to receive(:sms_gateway_service).and_return(sms_gateway_service)
+  end
+
+  after do
+    allow(Decidim.config).to receive(:sms_gateway_service).and_call_original
   end
 
   context "with multiple budgets" do

--- a/spec/system/budgets_view_spec.rb
+++ b/spec/system/budgets_view_spec.rb
@@ -7,9 +7,14 @@ describe "Budgets view", type: :system do
   let(:projects_count) { 1 }
   let(:decidim_budgets) { Decidim::EngineRouter.main_proxy(component) }
   let(:user) { create(:user, :confirmed, organization: organization) }
+  let(:sms_gateway_service) { "Decidim::Verifications::Sms::ExampleGateway" }
 
   before do
     switch_to_host(organization.host)
+
+    Decidim.configure do |config|
+      config.sms_gateway_service = sms_gateway_service
+    end
   end
 
   context "with multiple budgets" do


### PR DESCRIPTION
### 🎩 Description

This PR has been made to disable the fact that you can activate the SMS authentication if you have not gateway provided.

### **⚠️ 🚨 It will automatically be enabled in local due to the fact that we have the SMS:ExampleGateway then please follow the test process to make sure that the feature works.

#### :pushpin: Related Issues

- [Release 2.4 - Amélioration half sign up](https://www.notion.so/opensourcepolitics/Release-2-4-Am-lioration-half-sign-up-515fe5373e364b518a5bf8da5dbb410a?pvs=4)

### 🔧 How to test

#### ⚠️ Engineering Setup ⚠️ 
- Generate your development app
- Access to your development_app files `config/decidim.rb`
- Go to line 225 and comment this line : 
 `  config.sms_gateway_service = 'Decidim::Verifications::Sms::ExampleGateway' `
- Execute your app 

##### 🌓 First Test
- Log as an Admin
- Access BackOffice
- Access to Settings and Authentication Settings
- Make sure that the checkbox for the sms authentication is disabled
- Try to enable the email authentication and make sure everything works

#### 😈 Second Test
- Log as an Admin
- Access BackOffice
- Access to Settings and Authentication Settings
- Make sure that the checkbox for the sms authentication is disabled
- Try to access HTML directly on your page (Right Click + Inspect)
- Search for the disabled checkbox and on the HTML modify it and get rid of the `disabled:"disabled"`
- Activate the field SMS Authentication
- Update the Org
- Make sure an error is appearing and that the method is not enabled

#### 👿 Third Test
- Reenable the ExampleGateway (uncomment the line in the config/decidim.rb file
- Relaunch your app
- Activate the sms authenticator
- Update the org
- Close your app (ctrl+C in your terminal)
- Comment the Gateway (comment the line)
- Try to update the methods using the email authentication
- Make sure when you update the org that the sms method has been disabled and that it still updated

### 🔨 Tasks

- [x] Update the command to ensure backend security
- [x] Modify the controller to add a new error management (:sms_service_not_configured)
- [x] Modify the view to disable the checkbox
- [x] Add locales
- [x] Add tests   