### PR TITLE
Fix unwanted +33 with email from verify message

### DIFF
--- a/app/controllers/decidim/half_signup/quick_auth_controller.rb
+++ b/app/controllers/decidim/half_signup/quick_auth_controller.rb
@@ -61,6 +61,7 @@ module Decidim
         @form = form(VerificationCodeForm).instance
         @verification_code = auth_session["code"]
         @info = set_contact_info
+        @mail = auth_session["email"] == @info
       end
 
       def authenticate

--- a/app/views/decidim/half_signup/quick_auth/verify.html.erb
+++ b/app/views/decidim/half_signup/quick_auth/verify.html.erb
@@ -11,7 +11,11 @@
           <div class="card__content">
             <h2 class="text-center"><%= t("enter_code", scope: "decidim.half_signup.quick_auth") %></h2>
             <p class="text-center">
-              <%= t("instruction", scope:"decidim.half_signup.quick_auth", contact_info: @info) %>
+              <% if @mail %>
+                <%= t("instruction_email", scope:"decidim.half_signup.quick_auth", contact_info: @info) %>
+              <% else  %>
+                <%= t("instruction", scope:"decidim.half_signup.quick_auth", contact_info: @info) %>
+              <% end %>
               <br>
               <%= auth_link_generator %>
             </p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -78,6 +78,7 @@ en:
           welcome: Welcome to the platform!
         enter_code: 'Please enter the code:'
         instruction: You should have received the code to %{contact_info}
+        instruction_email: You should have received the code to %{contact_info}
         options:
           email: To your email
           not_allowed: You are not allowed to perform this action.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -94,6 +94,7 @@ fr:
           welcome: Bienvenue sur la plateforme !
         enter_code: 'Veuillez saisir le code :'
         instruction: Vous devriez avoir reçu le code à +33%{contact_info}
+        instruction_email: Vous devriez avoir reçu le code à %{contact_info}
         options:
           classic_connection: Se connecter en utilisant la méthode classique
           email: À votre e-mail


### PR DESCRIPTION
🎩 Description
When signing up with email, remove the +33 in the verify message "Vous devriez avoir reçu le code à..."

📌 Related Issues
[Notion card](https://www.notion.so/opensourcepolitics/bd4bf860eab94f9daca7da803f09e3b2?v=c96df65755dd403d95e86f82d7749709&p=d7d025cf58854090adfca712c9ae29b1&pm=c)

Testing

1. As an admin, "Enable partial sign up and sign in using SMS verification" and "Enable partial sign up and sign in using email verification" in the settings
2. As a user, in french locale, go to sign up, choose email, enter an email and in the verify page, check that you don't have the +33 in the message above the code to enter (cf screenshot)

Screenshot
<img width="599" alt="Capture d’écran 2024-08-21 à 15 23 32" src="https://github.com/user-attachments/assets/4b0c4d86-4ee5-431c-97a3-6fcaade72a60">
