### PR TITLE
fix(ci): Addition of assets compilation after app generation

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -29,11 +29,19 @@ def seed_db(path)
   end
 end
 
+def compile_assets(path)
+  Dir.chdir(path) do
+    system("yarn install")
+    system("bundle exec rails assets:precompile")
+  end
+end
+
 desc "Generates a dummy app for testing"
 task test_app: "decidim:generate_external_test_app" do
   ENV["RAILS_ENV"] = "test"
   fix_babel_config("spec/decidim_dummy_app")
   install_module("spec/decidim_dummy_app")
+  compile_assets("spec/decidim_dummy_app")
 end
 
 desc "Generates a development app"


### PR DESCRIPTION
This PR fixes the CI that crashed because of missing assets.

It adds a new step in the creation of the test decidim_dummy_app that will compile the assets afterwards its creation